### PR TITLE
Dark mode added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ The repository contains two intentionally different experiences:
 `-- AGENTS.md                  Repository development guidance
 ```
 
-The professional page uses semantic HTML and CSS without client-side JavaScript.
-The Sandbox keeps its original JavaScript and legacy dependencies isolated under
-`sandbox/`.
+The professional page uses semantic HTML and CSS, plus one small inline
+controller for its persisted light and dark theme toggle. When JavaScript is
+unavailable or no manual preference is stored, CSS continues to follow the
+visitor's system color preference. The Sandbox keeps its original JavaScript
+and legacy dependencies isolated under `sandbox/`.
 
 ## Local development
 

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -1,6 +1,6 @@
 # Portfolio project context
 
-Last verified against the repository: 2026-07-27
+Last verified against the repository: 2026-07-28
 
 This file is the durable current-state handoff for future development sessions.
 Read it with `AGENTS.md` before proposing or implementing work. If
@@ -32,6 +32,8 @@ Implemented:
   vendor scripts, and images.
 - A downloadable resume at `assets/Hyrum-Butler-Resume.pdf`.
 - Professional-page favicon and social-preview assets under `assets/`.
+- System-preference light and dark themes on the professional page, with a
+  persisted manual header toggle that uses `data-theme` for explicit choices.
 - Semantic page regions, a keyboard-visible skip link, responsive layouts,
   visible focus states, reduced-motion handling, and WCAG AA-oriented contrast.
 - A sticky desktop header and an intentionally sticky experience-section
@@ -46,8 +48,12 @@ Implemented:
   hero-to-work survey line, a contained sticky Ocean Intelligence field note,
   and a subtle project-link contour response.
 
-The professional page currently uses no JavaScript. Its behavior comes from
-semantic HTML and CSS. Sandbox JavaScript remains scoped to `sandbox/`.
+The professional page uses one small inline theme controller in `index.html`.
+It validates stored `light` and `dark` choices, applies a valid choice before
+the stylesheet loads, synchronizes the header toggle, and safely tolerates
+unavailable storage. With JavaScript unavailable or no manual choice stored,
+CSS follows `prefers-color-scheme`. Sandbox JavaScript remains scoped to
+`sandbox/`.
 
 Not implemented:
 
@@ -188,6 +194,8 @@ constitute visual verification.
 - Preserve the Sandbox rather than redesigning or broadly reformatting it.
 - Prefer native HTML and CSS over JavaScript for professional-page behavior.
 - Preserve accessibility behavior while refining visual composition.
+- Preserve CSS-only system theming when JavaScript is unavailable, and use
+  `data-theme` only for a visitor's explicit light or dark choice.
 - Use desktop-specific composition when useful without weakening the strong
   mobile experience.
 - Keep subtle editorial interactions restrained and non-distracting.

--- a/index.html
+++ b/index.html
@@ -37,6 +37,70 @@
 
     <!-- Relative URLs keep this project-site portable beneath GitHub Pages' /mysite/ path. -->
     <link rel="icon" href="./assets/images/favicon.ico" />
+    <script>
+      (() => {
+        const storageKey = "professional-portfolio-theme";
+        const darkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+        let storedTheme;
+
+        try {
+          const value = localStorage.getItem(storageKey);
+          if (value === "light" || value === "dark") {
+            storedTheme = value;
+            document.documentElement.dataset.theme = value;
+          }
+        } catch {
+          storedTheme = undefined;
+        }
+
+        const initializeToggle = () => {
+          const toggle = document.querySelector(".theme-toggle");
+          if (!toggle) {
+            return;
+          }
+
+          const state = toggle.querySelector(".theme-toggle__state");
+          const isDark = () => {
+            const theme = document.documentElement.dataset.theme;
+            return theme === "dark" || (theme !== "light" && darkModeQuery.matches);
+          };
+          const synchronizeToggle = () => {
+            const dark = isDark();
+            toggle.setAttribute("aria-pressed", String(dark));
+            state.textContent = dark ? "On" : "Off";
+          };
+
+          toggle.addEventListener("click", () => {
+            const theme = isDark() ? "light" : "dark";
+            document.documentElement.dataset.theme = theme;
+            storedTheme = theme;
+
+            try {
+              localStorage.setItem(storageKey, theme);
+            } catch {
+              // The selected theme still applies for the current document.
+            }
+
+            synchronizeToggle();
+          });
+
+          darkModeQuery.addEventListener("change", () => {
+            if (!storedTheme && !document.documentElement.dataset.theme) {
+              synchronizeToggle();
+            }
+          });
+
+          synchronizeToggle();
+          toggle.hidden = false;
+        };
+
+        if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", initializeToggle);
+        } else {
+          initializeToggle();
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="./styles/portfolio.css" />
   </head>
 
@@ -47,16 +111,23 @@
       <div class="site-header__inner">
         <a class="site-brand" href="#top" aria-label="Hyrum Butler, back to top"> Hyrum Butler </a>
 
-        <nav class="site-nav" aria-label="Primary navigation">
-          <ul>
-            <li><a href="#work">Work</a></li>
-            <li><a href="#experience">Experience</a></li>
-            <li><a href="#approach">Approach</a></li>
-            <li><a href="#about">About</a></li>
-            <li><a href="#contact">Contact</a></li>
-            <li><a class="site-nav__sandbox" href="./sandbox/">Hyrum's Sandbox</a></li>
-          </ul>
-        </nav>
+        <div class="site-header__controls">
+          <nav class="site-nav" aria-label="Primary navigation">
+            <ul>
+              <li><a href="#work">Work</a></li>
+              <li><a href="#experience">Experience</a></li>
+              <li><a href="#approach">Approach</a></li>
+              <li><a href="#about">About</a></li>
+              <li><a href="#contact">Contact</a></li>
+              <li><a class="site-nav__sandbox" href="./sandbox/">Hyrum's Sandbox</a></li>
+            </ul>
+          </nav>
+
+          <button class="theme-toggle" type="button" aria-pressed="false" hidden>
+            <span>Dark mode</span>
+            <span class="theme-toggle__state" aria-hidden="true">Off</span>
+          </button>
+        </div>
       </div>
     </header>
 

--- a/styles/portfolio.css
+++ b/styles/portfolio.css
@@ -1,4 +1,5 @@
 :root {
+  color-scheme: light;
   --paper: #f3f0e7;
   --paper-strong: #e7e1d4;
   --surface: #fbfaf6;
@@ -10,10 +11,48 @@
   --warm: #956247;
   --line: #c9c1b3;
   --focus: #166f8f;
+  --surface-featured: #203c34;
+  --surface-contact: #4c6877;
+  --surface-footer: #202a26;
+  --text-on-dark: #fbfaf6;
+  --focus-on-dark: #fbfaf6;
+  --featured-ring: #f3f0e7;
   --font-display: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
   --font-body:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --paper: #161d1a;
+  --paper-strong: #1d2723;
+  --surface: #202c27;
+  --ink: #edf0ea;
+  --ink-soft: #bcc7c0;
+  --pine: #8db8a4;
+  --pine-dark: #b0cfbf;
+  --slate: #91b1bf;
+  --warm: #d39a77;
+  --line: #46534d;
+  --focus: #79c7e3;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+    --paper: #161d1a;
+    --paper-strong: #1d2723;
+    --surface: #202c27;
+    --ink: #edf0ea;
+    --ink-soft: #bcc7c0;
+    --pine: #8db8a4;
+    --pine-dark: #b0cfbf;
+    --slate: #91b1bf;
+    --warm: #d39a77;
+    --line: #46534d;
+    --focus: #79c7e3;
+  }
 }
 
 *,
@@ -89,7 +128,7 @@ p {
 .featured-project :focus-visible,
 .section--contact :focus-visible,
 .site-footer :focus-visible {
-  outline-color: var(--surface);
+  outline-color: var(--focus-on-dark);
 }
 
 .skip-link {
@@ -141,6 +180,14 @@ p {
   text-decoration: none;
 }
 
+.site-header__controls {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem 1.25rem;
+}
+
 .site-nav ul {
   display: flex;
   margin: 0;
@@ -168,6 +215,40 @@ p {
   margin-left: 0.35rem;
   content: "↗";
   color: var(--warm);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  min-height: 2.75rem;
+  padding: 0.45rem 0.7rem;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid var(--line);
+  border-radius: 0.2rem;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.theme-toggle[hidden] {
+  display: none;
+}
+
+.theme-toggle:hover {
+  background: var(--paper-strong);
+}
+
+.theme-toggle__state {
+  color: var(--pine);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .hero {
@@ -426,8 +507,8 @@ p {
   position: relative;
   overflow: hidden;
   padding: clamp(1.5rem, 4vw, 3.25rem);
-  background: var(--pine-dark);
-  color: var(--paper);
+  background: var(--surface-featured);
+  color: var(--text-on-dark);
 }
 
 .featured-project::before {
@@ -436,11 +517,11 @@ p {
   right: -9rem;
   width: 25rem;
   height: 25rem;
-  border: 1px solid color-mix(in srgb, var(--paper) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--featured-ring) 16%, transparent);
   border-radius: 50%;
   box-shadow:
-    0 0 0 2rem color-mix(in srgb, var(--paper) 4%, transparent),
-    0 0 0 4.5rem color-mix(in srgb, var(--paper) 3%, transparent);
+    0 0 0 2rem color-mix(in srgb, var(--featured-ring) 4%, transparent),
+    0 0 0 4.5rem color-mix(in srgb, var(--featured-ring) 3%, transparent);
   content: "";
   pointer-events: none;
   transition:
@@ -451,10 +532,10 @@ p {
 
 /* The rings respond only to the real project link so the static card never looks clickable. */
 .featured-project:has(.featured-project__link:is(:hover, :focus-visible))::before {
-  border-color: color-mix(in srgb, var(--paper) 24%, transparent);
+  border-color: color-mix(in srgb, var(--featured-ring) 24%, transparent);
   box-shadow:
-    0 0 0 2rem color-mix(in srgb, var(--paper) 6%, transparent),
-    0 0 0 4.5rem color-mix(in srgb, var(--paper) 5%, transparent);
+    0 0 0 2rem color-mix(in srgb, var(--featured-ring) 6%, transparent),
+    0 0 0 4.5rem color-mix(in srgb, var(--featured-ring) 5%, transparent);
   transform: translate(-0.4rem, 0.4rem);
 }
 
@@ -493,7 +574,7 @@ p {
 }
 
 .featured-project__link {
-  color: var(--paper);
+  color: var(--text-on-dark);
   font-size: 0.9rem;
   font-weight: 750;
 }
@@ -557,7 +638,7 @@ p {
   z-index: 1;
   width: 1.05rem;
   height: 1.05rem;
-  background: var(--pine-dark);
+  background: var(--surface-featured);
   color: #b7cbc1;
   content: "→";
   line-height: 1;
@@ -781,8 +862,8 @@ p {
 .section--contact {
   position: relative;
   overflow: hidden;
-  background: var(--slate);
-  color: var(--surface);
+  background: var(--surface-contact);
+  color: var(--text-on-dark);
 }
 
 .contact-layout {
@@ -818,7 +899,7 @@ p {
   justify-content: space-between;
   gap: 1rem;
   border-bottom: 1px solid #91a7b2;
-  color: var(--surface);
+  color: var(--text-on-dark);
   font-family: var(--font-display);
   font-size: 1.2rem;
   text-decoration: none;
@@ -848,7 +929,7 @@ p {
   background: repeating-radial-gradient(
     ellipse at 48% 52%,
     transparent 0 1.75rem,
-    color-mix(in srgb, var(--surface) 20%, transparent) 1.8rem 1.88rem,
+    color-mix(in srgb, var(--text-on-dark) 20%, transparent) 1.8rem 1.88rem,
     transparent 1.93rem 3.35rem
   );
 }
@@ -885,7 +966,7 @@ p {
 
 .site-footer {
   padding-block: 1.5rem;
-  background: var(--ink);
+  background: var(--surface-footer);
   color: #d8ded9;
 }
 
@@ -1066,6 +1147,12 @@ p {
     gap: 0.25rem;
   }
 
+  .site-header__controls {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
   .site-nav ul {
     gap: 0 1rem;
     flex-wrap: wrap;
@@ -1126,8 +1213,13 @@ p {
     width: min(100% - 2.5rem, 72rem);
   }
 
-  .site-nav {
+  .site-nav,
+  .theme-toggle {
     width: 100%;
+  }
+
+  .theme-toggle {
+    justify-content: space-between;
   }
 
   .site-nav ul {


### PR DESCRIPTION
## Type
- [ ] Fix
- [ ] Update
- [x] Feature

## Description
- Adds system-preference dark mode to the professional portfolio.
- Adds an accessible header toggle for manual light and dark selection.
- Persists valid manual preferences and applies them before the stylesheet loads.
- Keeps CSS-only system theming available when JavaScript or storage is unavailable.
- Preserves the existing light palette, responsive layout, focus behavior, and field-guide identity.
- Keeps intentionally dark sections visually distinct across both themes.
- Leaves Hyrum's Sandbox, dependencies, assets, routing, and deployment configuration unchanged.
- Updates repository documentation to reflect the new theme behavior.
- Passes lint, focused Prettier verification, inline-script syntax validation, and `git diff --check`.

## Relevant Links
- [Professional portfolio](https://brazenbillygoat.github.io/mysite/)

## Files Worth Mentioning
- `index.html` - Adds the early theme initializer and accessible header toggle.
- `styles/portfolio.css` - Adds light and dark theme tokens, invariant dark-surface colors, and responsive toggle styling.
- `README.md` - Documents the inline theme controller and CSS-only fallback.
- `docs/PROJECT_CONTEXT.md` - Records the implemented theme behavior and current verification state.

## Screenshots
<img width="91" height="38" alt="image" src="https://github.com/user-attachments/assets/90943d7a-7879-425c-871a-1e04d1820038" />
<img width="361" height="235" alt="image" src="https://github.com/user-attachments/assets/d02aea95-bc4d-4e7e-a5e4-d0a9d12f4bfd" />
<img width="356" height="248" alt="image" src="https://github.com/user-attachments/assets/bd903097-4fc9-44cc-aede-a35d50b5c120" />